### PR TITLE
Fix TestOAuthRequestHeader

### DIFF
--- a/pkg/cmd/server/api/helpers.go
+++ b/pkg/cmd/server/api/helpers.go
@@ -409,7 +409,7 @@ func GetClientCertCAPool(options MasterConfig) (*x509.CertPool, error) {
 	roots := x509.NewCertPool()
 
 	// Add CAs for OAuth
-	certs, err := getOAuthClientCertCAs(options)
+	certs, err := GetOAuthClientCertCAs(options)
 	if err != nil {
 		return nil, err
 	}
@@ -429,7 +429,7 @@ func GetClientCertCAPool(options MasterConfig) (*x509.CertPool, error) {
 	return roots, nil
 }
 
-func getOAuthClientCertCAs(options MasterConfig) ([]*x509.Certificate, error) {
+func GetOAuthClientCertCAs(options MasterConfig) ([]*x509.Certificate, error) {
 	if !UseTLS(options.ServingInfo.ServingInfo) {
 		return nil, nil
 	}

--- a/pkg/cmd/server/kubernetes/master_config.go
+++ b/pkg/cmd/server/kubernetes/master_config.go
@@ -275,6 +275,10 @@ func BuildKubernetesMasterConfig(options configapi.MasterConfig, requestContextM
 	}
 	genericConfig.LoopbackClientConfig = loopbackClientConfig
 	genericConfig.SecureServingInfo.BindNetwork = options.ServingInfo.BindNetwork
+	genericConfig.SecureServingInfo.ExtraClientCACerts, err = configapi.GetOAuthClientCertCAs(options)
+	if err != nil {
+		glog.Fatalf("Error setting up OAuth2 client certificates: %v", err)
+	}
 	url, err := url.Parse(options.MasterPublicURL)
 	if err != nil {
 		glog.Fatalf("Error parsing master public url %q: %v", options.MasterPublicURL, err)

--- a/vendor/k8s.io/kubernetes/pkg/genericapiserver/config.go
+++ b/vendor/k8s.io/kubernetes/pkg/genericapiserver/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package genericapiserver
 
 import (
+	"crypto/x509"
 	"fmt"
 	"io"
 	"net"
@@ -170,6 +171,9 @@ type SecureServingInfo struct {
 	SNICerts []NamedCertKey
 	// ClientCA is the certificate bundle for all the signers that you'll recognize for incoming client certificates
 	ClientCA string
+	// ExtraClientCACerts are additional ClientCA certs added to the pool.
+	// TODO(sttts): remove again with Kube 1.6
+	ExtraClientCACerts []*x509.Certificate
 }
 
 type CertKey struct {


### PR DESCRIPTION
The OAuth authenticator uses its own client CA. The requests from the proxy to the backend use a matching client cert. But because it does not match to the generic API client CA, the go TLS stack was rejecting it and did not set `req.TLS.PeerCertificates`. Hence, the OAuth autenticator never saw the client CA of the proxy, returning a redirection back to the proxy itself.

Kube 1.5 only supports one client CA and has no way to tweak the client CA x509 pool afterwards. We have to carry a small upstream patch for that in 1.5. For 1.6 we have rewritten the cert loading and moved it to the options application. Hence, we can access the client CA pool there such that we can drop the patch again for 1.6.